### PR TITLE
docs: Cloudflare 無料枠 β版 設計書・実装計画

### DIFF
--- a/docs/superpowers/plans/2026-07-11-fork-cloudflare-beta.md
+++ b/docs/superpowers/plans/2026-07-11-fork-cloudflare-beta.md
@@ -1,0 +1,601 @@
+# fork Cloudflare β版 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** LiveKit + Vercel 依存を除去し、Cloudflare 無料枠（Pages / Workers / D1 / DO / Realtime SFU）だけで音声ライブ配信 β を運用可能にする。
+
+**Architecture:** Next.js UI を Cloudflare Pages (OpenNext) に載せ、API・認証・SFU セッション発行を Workers + D1 で行う。ルーム単位のリアルタイム状態（視聴者数・チャット）は WebSocket Hibernation 対応の RoomDO が担当。メディアは Cloudflare Realtime SFU（月 1,000 GB 無料）。
+
+**Tech Stack:** Cloudflare Workers, Durable Objects, D1, KV, Pages, OpenNext, Realtime SFU, Hono, Drizzle ORM, Auth.js, Vitest, Playwright
+
+**Design Spec:** `docs/superpowers/specs/2026-07-11-fork-cloudflare-design.md`
+
+---
+
+## File Structure (新規)
+
+```
+/
+├── wrangler.toml                 # Workers + D1 + DO + KV bindings
+├── worker/
+│   ├── src/
+│   │   ├── index.ts              # Hono app entry
+│   │   ├── env.ts                # Env type definitions
+│   │   ├── routes/
+│   │   │   ├── auth.ts
+│   │   │   ├── room.ts
+│   │   │   ├── session.ts        # SFU session minting
+│   │   │   ├── reaction.ts
+│   │   │   └── moderation.ts
+│   │   ├── durable-objects/
+│   │   │   └── room.ts           # RoomDO
+│   │   ├── lib/
+│   │   │   ├── sfu.ts            # Realtime SFU HTTPS API client
+│   │   │   ├── rate-limit.ts     # KV-based limiter
+│   │   │   └── host-lifecycle.ts
+│   │   └── cron/
+│   │       └── cleanup.ts
+│   └── test/
+│       ├── room-do.test.ts
+│       └── host-lifecycle.test.ts
+├── packages/
+│   └── db/
+│       ├── schema.ts             # Drizzle D1 schema
+│       └── migrations/
+└── web/                          # 既存 Next.js（段階的に SFU client 差し替え）
+    └── src/lib/
+        ├── sfu-client.ts         # WebRTC + SFU session helper
+        └── room-ws.ts            # RoomDO WebSocket client
+```
+
+---
+
+## Phase 0: Cloudflare 基盤セットアップ
+
+### Task 0: Wrangler プロジェクト初期化
+
+**Files:**
+- Create: `wrangler.toml`
+- Create: `worker/src/index.ts`
+- Create: `worker/src/env.ts`
+- Create: `packages/db/schema.ts`
+
+- [ ] **Step 1: wrangler.toml を作成**
+
+```toml
+name = "fork-api"
+main = "worker/src/index.ts"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "fork"
+database_id = "<CREATE_VIA_CLI>"
+
+[[kv_namespaces]]
+binding = "KV"
+id = "<CREATE_VIA_CLI>"
+
+[durable_objects]
+bindings = [{ name = "ROOM", class_name = "RoomDO" }]
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["RoomDO"]
+
+[triggers]
+crons = ["*/5 * * * *"]
+
+[vars]
+# REALTIME_APP_ID set via wrangler secret
+```
+
+- [ ] **Step 2: D1 データベース作成**
+
+Run:
+```bash
+npx wrangler d1 create fork
+npx wrangler kv namespace create FORK_KV
+```
+Expected: database_id / kv id が出力される → wrangler.toml に反映
+
+- [ ] **Step 3: Drizzle スキーマ定義**
+
+`packages/db/schema.ts`:
+```typescript
+import { sqliteTable, text, integer, primaryKey } from "drizzle-orm/sqlite-core";
+
+export const rooms = sqliteTable("rooms", {
+  name: text("name").primaryKey(),
+  displayName: text("display_name"),
+  hostIdentity: text("host_identity"),
+  isPublic: integer("is_public", { mode: "boolean" }).notNull().default(true),
+  hostLastSeenAt: text("host_last_seen_at"),
+  createdAt: text("created_at").notNull(),
+});
+
+export const bans = sqliteTable("bans", {
+  roomName: text("room_name").notNull(),
+  identity: text("identity").notNull(),
+  createdAt: text("created_at").notNull(),
+}, (t) => [primaryKey({ columns: [t.roomName, t.identity] })]);
+
+export const reactionAggregates = sqliteTable("reaction_aggregates", {
+  roomName: text("room_name").notNull(),
+  type: text("type").notNull(),
+  count: integer("count").notNull().default(0),
+}, (t) => [primaryKey({ columns: [t.roomName, t.type] })]);
+
+export const adminUsers = sqliteTable("admin_users", {
+  identity: text("identity").primaryKey(),
+});
+```
+
+- [ ] **Step 4: マイグレーション SQL 適用**
+
+Create `packages/db/migrations/0001_init.sql`（設計書 §6 の DDL）を作成し:
+```bash
+npx wrangler d1 execute fork --remote --file=packages/db/migrations/0001_init.sql
+npx wrangler d1 execute fork --local --file=packages/db/migrations/0001_init.sql
+```
+
+- [ ] **Step 5: Hono エントリポイント**
+
+`worker/src/index.ts`:
+```typescript
+import { Hono } from "hono";
+import type { Env } from "./env";
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.get("/api/health", (c) => c.json({ ok: true }));
+
+export default app;
+export { RoomDO } from "./durable-objects/room";
+```
+
+- [ ] **Step 6: ローカル起動確認**
+
+Run: `npx wrangler dev`
+Expected: `GET http://localhost:8787/api/health` → `{"ok":true}`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add wrangler.toml worker/ packages/db/
+git commit -m "feat: add Cloudflare Workers foundation with D1 schema"
+```
+
+---
+
+### Task 1: RoomDO スケルトン（WebSocket Hibernation）
+
+**Files:**
+- Create: `worker/src/durable-objects/room.ts`
+- Create: `worker/test/room-do.test.ts`
+
+- [ ] **Step 1: 失敗テストを書く**
+
+`worker/test/room-do.test.ts`:
+```typescript
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+
+describe("RoomDO", () => {
+  it("returns viewer count on connect", async () => {
+    const id = env.ROOM.idFromName("test-room");
+    const stub = env.ROOM.get(id);
+    const res = await stub.fetch("https://do/viewer-count");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ viewers: number }>();
+    expect(body.viewers).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: テスト実行（FAIL 確認）**
+
+Run: `npx vitest run worker/test/room-do.test.ts`
+Expected: FAIL — RoomDO not implemented
+
+- [ ] **Step 3: RoomDO 実装**
+
+`worker/src/durable-objects/room.ts`:
+```typescript
+import { DurableObject } from "cloudflare:workers";
+
+export class RoomDO extends DurableObject {
+  private viewers = new Set<string>();
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/viewer-count") {
+      return Response.json({ viewers: this.viewers.size });
+    }
+    if (request.headers.get("Upgrade") === "websocket") {
+      const pair = new WebSocketPair();
+      const [client, server] = Object.values(pair);
+      this.ctx.acceptWebSocket(server);
+      return new Response(null, { status: 101, webSocket: client });
+    }
+    return new Response("not found", { status: 404 });
+  }
+
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer) {
+    const data = typeof message === "string" ? JSON.parse(message) : null;
+    if (data?.type === "join" && typeof data.identity === "string") {
+      this.viewers.add(data.identity);
+      ws.send(JSON.stringify({ type: "viewers", count: this.viewers.size }));
+      this.broadcast(JSON.stringify({ type: "viewers", count: this.viewers.size }));
+    }
+  }
+
+  async webSocketClose(ws: WebSocket) {
+    // identity は join 時に ws.serializeAttachment で保存する（Task 2 で拡張）
+  }
+
+  private broadcast(payload: string) {
+    for (const ws of this.ctx.getWebSockets()) {
+      ws.send(payload);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: テスト PASS 確認**
+
+Run: `npx vitest run worker/test/room-do.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add worker/src/durable-objects/room.ts worker/test/room-do.test.ts
+git commit -m "feat: add RoomDO with WebSocket hibernation skeleton"
+```
+
+---
+
+## Phase 1: Realtime SFU 音声配信
+
+### Task 2: SFU セッション発行 API
+
+**Files:**
+- Create: `worker/src/lib/sfu.ts`
+- Create: `worker/src/routes/session.ts`
+- Modify: `worker/src/index.ts`
+
+- [ ] **Step 1: SFU API クライアント**
+
+`worker/src/lib/sfu.ts` — Cloudflare Realtime SFU HTTPS API ラッパー:
+```typescript
+const SFU_BASE = "https://rtc.live.cloudflare.com/v1";
+
+export async function createSession(appId: string, appSecret: string): Promise<string> {
+  const res = await fetch(`${SFU_BASE}/apps/${appId}/sessions/new`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${appSecret}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({}),
+  });
+  if (!res.ok) throw new Error(`SFU session create failed: ${res.status}`);
+  const json = await res.json<{ sessionId: string }>();
+  return json.sessionId;
+}
+
+export async function createPublishTrack(
+  appId: string,
+  appSecret: string,
+  sessionId: string,
+): Promise<{ trackName: string; sdpOffer: string }> {
+  const res = await fetch(`${SFU_BASE}/apps/${appId}/sessions/${sessionId}/tracks/new`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${appSecret}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      tracks: [{ location: "local", kind: "audio", mimeType: "audio/opus" }],
+    }),
+  });
+  if (!res.ok) throw new Error(`SFU track create failed: ${res.status}`);
+  const json = await res.json<{ tracks: Array<{ trackName: string; sdpOffer: string }> }>();
+  return json.tracks[0];
+}
+```
+
+- [ ] **Step 2: `/api/session` ルート**
+
+`worker/src/routes/session.ts` — 認証済みユーザーに SFU sessionId + role(host/viewer) を返す。host の場合は `rooms.host_identity` をセット、viewer は subscribe track を返す。
+
+- [ ] **Step 3: Secrets 設定**
+
+```bash
+npx wrangler secret put REALTIME_APP_ID
+npx wrangler secret put REALTIME_APP_SECRET
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat: add Realtime SFU session API"
+```
+
+---
+
+### Task 3: フロントエンド SFU クライアント
+
+**Files:**
+- Create: `web/src/lib/sfu-client.ts`
+- Modify: `web/src/pages/room/[name].tsx`
+- Modify: `web/src/components/InRoomUI.tsx`
+- Delete usage: `@livekit/components-react`, `livekit-client`（最終 Step）
+
+- [ ] **Step 1: sfu-client.ts — RTCPeerConnection ラッパー**
+
+```typescript
+export class SfuAudioClient {
+  private pc: RTCPeerConnection;
+
+  constructor(private sessionId: string) {
+    this.pc = new RTCPeerConnection({
+      iceServers: [{ urls: "stun:stun.cloudflare.com:3478" }],
+    });
+  }
+
+  async publishMic(): Promise<void> {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    for (const track of stream.getAudioTracks()) {
+      this.pc.addTrack(track, stream);
+    }
+    // SDP offer/answer exchange via /api/session/* endpoints
+  }
+
+  async subscribeRemoteAudio(onTrack: (track: MediaStreamTrack) => void): Promise<void> {
+    this.pc.ontrack = (ev) => {
+      if (ev.track.kind === "audio") onTrack(ev.track);
+    };
+  }
+
+  disconnect(): void {
+    this.pc.close();
+  }
+}
+```
+
+- [ ] **Step 2: InRoomUI を SfuAudioClient に差し替え**
+
+`LiveKitRoom` / `useRoomContext` を除去。マイク toggle は `MediaStreamTrack.enabled` で制御。
+
+- [ ] **Step 3: DataChannel でリアクション broadcast**
+
+SFU DataChannels API を使用（`topic: "reaction"` 相当）。既存 UI の 👍/🎁 ボタンは維持。
+
+- [ ] **Step 4: package.json から livekit 依存削除**
+
+```bash
+cd web && npm uninstall @livekit/components-react livekit-client
+```
+
+- [ ] **Step 5: E2E 更新**
+
+`web/tests/room.page.spec.ts` — LiveKit セレクタを SFU 接続状態バッジに変更。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat: replace LiveKit with Cloudflare Realtime SFU client"
+```
+
+---
+
+## Phase 2: 状態管理・host ライフサイクル
+
+### Task 4: hostIdentity 解放
+
+**Files:**
+- Create: `worker/src/lib/host-lifecycle.ts`
+- Create: `worker/src/cron/cleanup.ts`
+- Modify: `worker/src/routes/session.ts`
+
+- [ ] **Step 1: 失敗テスト**
+
+`worker/test/host-lifecycle.test.ts`:
+```typescript
+it("clears host_identity when host inactive for 60s", async () => {
+  // seed room with host + old host_last_seen_at
+  // run cleanup
+  // expect host_identity IS NULL
+});
+```
+
+- [ ] **Step 2: host-lifecycle.ts 実装**
+
+```typescript
+export async function releaseStaleHosts(db: D1Database, thresholdSec = 60): Promise<number> {
+  const cutoff = new Date(Date.now() - thresholdSec * 1000).toISOString();
+  const result = await db
+    .prepare(
+      `UPDATE rooms SET host_identity = NULL, host_last_seen_at = NULL
+       WHERE host_identity IS NOT NULL AND host_last_seen_at < ?`,
+    )
+    .bind(cutoff)
+    .run();
+  return result.meta.changes ?? 0;
+}
+```
+
+- [ ] **Step 3: 配信終了 API**
+
+`POST /api/room/end` — host のみ。`host_identity = NULL`、RoomDO に `{ type: "stream_ended" }` broadcast。
+
+- [ ] **Step 4: Cron 5 分ごとに cleanup 実行**
+
+- [ ] **Step 5: フロント — 退出時 `/api/room/end` 呼び出し**
+
+`InRoomUI` の「配信終了」ボタンから呼ぶ。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "fix: release host_identity on stream end and stale timeout"
+```
+
+---
+
+### Task 5: 視聴者数 WebSocket 移行
+
+**Files:**
+- Create: `web/src/lib/room-ws.ts`
+- Modify: `web/src/components/InRoomUI.tsx`
+- Remove: `web/src/pages/api/room/viewers/stream.ts`（Workers 移行後）
+
+- [ ] **Step 1: room-ws.ts クライアント**
+
+```typescript
+export function connectRoomWs(slug: string, identity: string, onViewers: (n: number) => void): WebSocket {
+  const ws = new WebSocket(`${location.origin.replace("http", "ws")}/api/room/${slug}/ws`);
+  ws.onopen = () => ws.send(JSON.stringify({ type: "join", identity }));
+  ws.onmessage = (ev) => {
+    const msg = JSON.parse(ev.data);
+    if (msg.type === "viewers") onViewers(msg.count);
+  };
+  return ws;
+}
+```
+
+- [ ] **Step 2: InRoomUI — SSE / presence heartbeat 削除、WS に置換**
+
+- [ ] **Step 3: RoomDO — disconnect 時 viewers Set から除去**
+
+`webSocketClose` で `serializeAttachment` から identity 取得 → delete → broadcast。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat: replace SSE viewer count with RoomDO WebSocket"
+```
+
+---
+
+## Phase 3: β 運用品質
+
+### Task 6: 管理者 RBAC
+
+**Files:**
+- Modify: `worker/src/routes/room.ts`
+- Modify: `web/src/pages/admin/monitor.tsx`
+
+- [ ] **Step 1: admin_users シード**
+
+```bash
+npx wrangler d1 execute fork --command "INSERT INTO admin_users (identity) VALUES ('<your-oauth-sub>')"
+```
+
+- [ ] **Step 2: `/api/admin/*` ミドルウェア**
+
+```typescript
+async function requireAdmin(c: Context, next: Next) {
+  const identity = c.get("identity");
+  const row = await c.env.DB.prepare("SELECT 1 FROM admin_users WHERE identity = ?").bind(identity).first();
+  if (!row) return c.json({ error: "forbidden" }, 403);
+  return next();
+}
+```
+
+- [ ] **Step 3: monitor ページ — 403 時は「権限がありません」表示**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat: add admin RBAC for monitor page"
+```
+
+---
+
+### Task 7: レートリミット + 共有リンク
+
+**Files:**
+- Create: `worker/src/lib/rate-limit.ts`
+- Modify: `worker/src/routes/reaction.ts`
+- Modify: `web/src/components/InRoomUI.tsx`
+
+- [ ] **Step 1: KV レートリミット（10 req/min/user/endpoint）**
+
+- [ ] **Step 2: reaction/send に適用 — 429 返却**
+
+- [ ] **Step 3: 共有リンク UI 追加**
+
+InRoomUI トップバーに「リンクをコピー」ボタン:
+```typescript
+await navigator.clipboard.writeText(`${location.origin}/room/${roomName}?publish=false`);
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat: add rate limiting and share link"
+```
+
+---
+
+### Task 8: Pages デプロイ + CI
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Create: `.github/workflows/deploy-cloudflare.yml`
+
+- [ ] **Step 1: OpenNext Cloudflare 設定**
+
+```bash
+cd web && npx @opennextjs/cloudflare init
+```
+
+- [ ] **Step 2: GitHub Actions — PR で vitest + playwright、main で wrangler deploy**
+
+- [ ] **Step 3: 環境変数を Cloudflare Dashboard / wrangler secret に設定**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "ci: add Cloudflare Pages and Workers deploy pipeline"
+```
+
+---
+
+## Phase 4: 将来（別 plan）
+
+- 映像 track 追加（帯域監視必須）
+- R2 録画（無料 10 GB 枠）
+- チャット D1 永続化（モデレーション）
+- カテゴリ・検索（KV + D1 index）
+
+---
+
+## 検証チェックリスト（β リリース前）
+
+- [ ] 配信者: 作成 → 配信 → 終了 → 同一 slug で再配信
+- [ ] 視聴者: 30 人同時接続で WS viewer count が一致
+- [ ] BAN されたユーザーは `/api/session` が 403
+- [ ] 非 admin が `/admin/monitor` で 403
+- [ ] LiveKit Docker なしでローカル dev 可能（wrangler dev + SFU credentials）
+- [ ] Cloudflare dashboard で SFU egress が想定内
+
+---
+
+## Self-Review（spec coverage）
+
+| Spec 要件 | Plan Task |
+|-----------|-----------|
+| SFU 無料枠 | Task 2, 3 |
+| host 解放 | Task 4 |
+| RoomDO WS | Task 1, 5 |
+| D1 スキーマ | Task 0 |
+| RBAC | Task 6 |
+| レートリミット | Task 7 |
+| KV キャッシュ | Task 0 (KV binding), Task 7 拡張で room list |
+| Cron cleanup | Task 4 |
+| OpenNext Pages | Task 8 |

--- a/docs/superpowers/plans/2026-07-11-fork-cloudflare-beta.md
+++ b/docs/superpowers/plans/2026-07-11-fork-cloudflare-beta.md
@@ -2,51 +2,68 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** LiveKit + Vercel 依存を除去し、Cloudflare 無料枠（Pages / Workers / D1 / DO / Realtime SFU）だけで音声ライブ配信 β を運用可能にする。
+**Goal:** LiveKit + Next.js + Vercel 依存を全廃し、Cloudflare 無料枠（Workers + Static Assets / D1 / DO / KV / Realtime SFU）だけで音声ライブ配信 β を運用可能にする。
 
-**Architecture:** Next.js UI を Cloudflare Pages (OpenNext) に載せ、API・認証・SFU セッション発行を Workers + D1 で行う。ルーム単位のリアルタイム状態（視聴者数・チャット）は WebSocket Hibernation 対応の RoomDO が担当。メディアは Cloudflare Realtime SFU（月 1,000 GB 無料）。
+**Architecture:** Vite + React SPA を Workers Static Assets で配信し、同一 Worker 上の Hono が API・OAuth・SFU セッションを担当。ルーム単位のリアルタイム状態は RoomDO（WebSocket Hibernation）。認証は Arctic + KV セッション。
 
-**Tech Stack:** Cloudflare Workers, Durable Objects, D1, KV, Pages, OpenNext, Realtime SFU, Hono, Drizzle ORM, Auth.js, Vitest, Playwright
+**Tech Stack:** Cloudflare Workers, Static Assets, Durable Objects, D1, KV, Realtime SFU, Vite, React, TanStack Router, Hono, Arctic, Drizzle ORM, Vitest, Playwright
 
 **Design Spec:** `docs/superpowers/specs/2026-07-11-fork-cloudflare-design.md`
 
 ---
 
-## File Structure (新規)
+## File Structure（確定）
 
 ```
 /
-├── wrangler.toml                 # Workers + D1 + DO + KV bindings
+├── package.json                  # npm workspaces root
+├── wrangler.toml                 # Worker + D1 + DO + KV + Static Assets
 ├── worker/
 │   ├── src/
-│   │   ├── index.ts              # Hono app entry
-│   │   ├── env.ts                # Env type definitions
+│   │   ├── index.ts              # Hono app + ASSETS fallback
+│   │   ├── env.ts
+│   │   ├── middleware/
+│   │   │   └── session.ts        # KV session from cookie
 │   │   ├── routes/
-│   │   │   ├── auth.ts
+│   │   │   ├── auth.ts           # Arctic OAuth (Google/X)
 │   │   │   ├── room.ts
-│   │   │   ├── session.ts        # SFU session minting
+│   │   │   ├── session.ts
 │   │   │   ├── reaction.ts
 │   │   │   └── moderation.ts
 │   │   ├── durable-objects/
-│   │   │   └── room.ts           # RoomDO
+│   │   │   └── room.ts
 │   │   ├── lib/
-│   │   │   ├── sfu.ts            # Realtime SFU HTTPS API client
-│   │   │   ├── rate-limit.ts     # KV-based limiter
+│   │   │   ├── sfu.ts
+│   │   │   ├── rate-limit.ts
 │   │   │   └── host-lifecycle.ts
 │   │   └── cron/
 │   │       └── cleanup.ts
 │   └── test/
-│       ├── room-do.test.ts
-│       └── host-lifecycle.test.ts
-├── packages/
-│   └── db/
-│       ├── schema.ts             # Drizzle D1 schema
-│       └── migrations/
-└── web/                          # 既存 Next.js（段階的に SFU client 差し替え）
-    └── src/lib/
-        ├── sfu-client.ts         # WebRTC + SFU session helper
-        └── room-ws.ts            # RoomDO WebSocket client
+├── app/                          # Vite + React SPA（web/ を置換）
+│   ├── index.html
+│   ├── vite.config.ts
+│   ├── src/
+│   │   ├── main.tsx
+│   │   ├── routes/
+│   │   │   ├── index.tsx         # ロビー
+│   │   │   ├── room.$slug.tsx    # 配信/視聴
+│   │   │   └── admin.monitor.tsx
+│   │   ├── components/
+│   │   │   ├── Chat.tsx
+│   │   │   ├── InRoomUI.tsx
+│   │   │   └── Participants.tsx
+│   │   └── lib/
+│   │       ├── api.ts            # fetch wrapper (credentials: include)
+│   │       ├── sfu-client.ts
+│   │       └── room-ws.ts
+│   └── e2e/                      # Playwright（新設）
+└── packages/
+    └── db/
+        ├── schema.ts
+        └── migrations/
 ```
+
+**廃止:** `web/` ディレクトリ全体（Next.js, NextAuth, Prisma, LiveKit, 旧 Playwright）
 
 ---
 
@@ -87,8 +104,14 @@ new_sqlite_classes = ["RoomDO"]
 [triggers]
 crons = ["*/5 * * * *"]
 
+[assets]
+directory = "./app/dist"
+not_found_handling = "single-page-application"
+binding = "ASSETS"
+
 [vars]
 # REALTIME_APP_ID set via wrangler secret
+# OAUTH redirect base = https://fork-api.<account>.workers.dev
 ```
 
 - [ ] **Step 2: D1 データベース作成**
@@ -140,18 +163,29 @@ npx wrangler d1 execute fork --remote --file=packages/db/migrations/0001_init.sq
 npx wrangler d1 execute fork --local --file=packages/db/migrations/0001_init.sql
 ```
 
-- [ ] **Step 5: Hono エントリポイント**
+- [ ] **Step 5: Hono エントリポイント（API + SPA fallback）**
 
 `worker/src/index.ts`:
 ```typescript
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import type { Env } from "./env";
 
 const app = new Hono<{ Bindings: Env }>();
 
 app.get("/api/health", (c) => c.json({ ok: true }));
 
-export default app;
+// Phase 1+ で auth/room ルートを追加
+
+export default {
+  fetch(request: Request, env: Env, ctx: ExecutionContext): Response | Promise<Response> {
+    return app.fetch(request, env, ctx).then((res) => {
+      if (res.status !== 404) return res;
+      return env.ASSETS.fetch(request);
+    });
+  },
+  scheduled: (event, env, ctx) => { /* cron */ },
+};
 export { RoomDO } from "./durable-objects/room";
 ```
 
@@ -257,6 +291,158 @@ git commit -m "feat: add RoomDO with WebSocket hibernation skeleton"
 
 ---
 
+### Task 1B: Vite + React SPA スキャフォールド
+
+**Files:**
+- Create: `app/package.json`, `app/vite.config.ts`, `app/index.html`
+- Create: `app/src/main.tsx`, `app/src/routes/__root.tsx`
+- Create: `package.json` (workspace root)
+- Remove: `web/`（Task 3 完了後に削除）
+
+- [ ] **Step 1: npm workspaces ルート**
+
+`/package.json`:
+```json
+{
+  "name": "fork",
+  "private": true,
+  "workspaces": ["app", "worker", "packages/db"],
+  "scripts": {
+    "dev": "npm run build:app && wrangler dev",
+    "build:app": "npm run build -w app",
+    "deploy": "npm run build:app && wrangler deploy",
+    "test": "vitest run",
+    "e2e": "playwright test -c app/playwright.config.ts"
+  }
+}
+```
+
+- [ ] **Step 2: Vite プロジェクト作成**
+
+```bash
+cd app && npm create vite@latest . -- --template react-ts
+npm install @tanstack/react-router @tanstack/router-plugin
+```
+
+`app/vite.config.ts` — dev proxy to wrangler:
+```typescript
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
+
+export default defineConfig({
+  plugins: [TanStackRouterVite(), react()],
+  server: {
+    proxy: { "/api": "http://localhost:8787" },
+  },
+  build: { outDir: "dist" },
+});
+```
+
+- [ ] **Step 3: 既存 UI を移植**
+
+`web/src/components/{Chat,InRoomUI,Participants}.tsx` → `app/src/components/`  
+`web/src/pages/globals.css` → `app/src/styles/globals.css`  
+LiveKit 依存コードは Stub に置換（Task 3 で SFU 接続に差し替え）
+
+- [ ] **Step 4: TanStack Router ルート**
+
+- `/` — ロビー（旧 `index.tsx` のロビー部分）
+- `/room/$slug` — 配信/視聴（`?publish=true|false` を search param で受ける）
+- `/admin/monitor` — 監視
+
+- [ ] **Step 5: api.ts ラッパー**
+
+```typescript
+export async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, { ...init, credentials: "include" });
+  if (!res.ok) throw new Error(`${path} ${res.status}`);
+  return res.json() as Promise<T>;
+}
+```
+
+- [ ] **Step 6: ビルド + wrangler dev で SPA 配信確認**
+
+Run:
+```bash
+npm run build:app && npx wrangler dev
+```
+Expected: `http://localhost:8787/` → Vite SPA、`/api/health` → JSON
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/ package.json
+git commit -m "feat: add Vite React SPA with TanStack Router"
+```
+
+---
+
+### Task 1C: Arctic OAuth + KV セッション
+
+**Files:**
+- Create: `worker/src/routes/auth.ts`
+- Create: `worker/src/middleware/session.ts`
+- Modify: `worker/src/index.ts`
+
+- [ ] **Step 1: Arctic インストール**
+
+```bash
+cd worker && npm install arctic hono
+```
+
+- [ ] **Step 2: session middleware**
+
+`worker/src/middleware/session.ts`:
+```typescript
+import type { Context, Next } from "hono";
+import type { Env } from "../env";
+
+const COOKIE = "__Host-fork-session";
+
+export async function requireSession(c: Context<{ Bindings: Env }>, next: Next) {
+  const sessionId = getCookie(c, COOKIE);
+  if (!sessionId) return c.json({ error: "unauthorized" }, 401);
+  const raw = await c.env.KV.get(`session:${sessionId}`, "json");
+  if (!raw) return c.json({ error: "unauthorized" }, 401);
+  c.set("user", raw as { userId: string; name: string });
+  return next();
+}
+
+export function getCookie(c: Context, name: string): string | undefined {
+  const header = c.req.header("Cookie") ?? "";
+  const match = header.match(new RegExp(`${name}=([^;]+)`));
+  return match?.[1];
+}
+```
+
+- [ ] **Step 3: auth routes (Google + X)**
+
+`worker/src/routes/auth.ts` — Arctic `Google`, `Twitter` クライアント。callback で:
+1. `crypto.randomUUID()` → sessionId
+2. `KV.put(`session:${id}`, { userId, name }, { expirationTtl: 604800 })`
+3. `Set-Cookie: __Host-fork-session=...`
+
+Secrets:
+```bash
+npx wrangler secret put GOOGLE_CLIENT_ID
+npx wrangler secret put GOOGLE_CLIENT_SECRET
+npx wrangler secret put TWITTER_CLIENT_ID
+npx wrangler secret put TWITTER_CLIENT_SECRET
+```
+
+- [ ] **Step 4: SPA ログインボタン**
+
+`app/src/routes/index.tsx` — `<a href="/api/auth/google">Googleでサインイン</a>`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat: add Arctic OAuth with KV session cookies"
+```
+
+---
+
 ## Phase 1: Realtime SFU 音声配信
 
 ### Task 2: SFU セッション発行 API
@@ -326,13 +512,16 @@ git commit -m "feat: add Realtime SFU session API"
 
 ---
 
-### Task 3: フロントエンド SFU クライアント
+### Task 3: フロントエンド SFU クライアント + web/ 削除
 
 **Files:**
-- Create: `web/src/lib/sfu-client.ts`
-- Modify: `web/src/pages/room/[name].tsx`
-- Modify: `web/src/components/InRoomUI.tsx`
-- Delete usage: `@livekit/components-react`, `livekit-client`（最終 Step）
+- Create: `app/src/lib/sfu-client.ts`
+- Create: `app/src/lib/room-ws.ts`
+- Modify: `app/src/components/InRoomUI.tsx`
+- Modify: `app/src/routes/room.$slug.tsx`
+- Delete: `web/` ディレクトリ全体
+- Delete: `livekit/` ディレクトリ（docker-compose）
+- Delete: `Makefile` の livekit ターゲット
 
 - [ ] **Step 1: sfu-client.ts — RTCPeerConnection ラッパー**
 
@@ -368,26 +557,27 @@ export class SfuAudioClient {
 
 - [ ] **Step 2: InRoomUI を SfuAudioClient に差し替え**
 
-`LiveKitRoom` / `useRoomContext` を除去。マイク toggle は `MediaStreamTrack.enabled` で制御。
+LiveKit 参照をすべて除去。マイク toggle は `MediaStreamTrack.enabled` で制御。
 
 - [ ] **Step 3: DataChannel でリアクション broadcast**
 
-SFU DataChannels API を使用（`topic: "reaction"` 相当）。既存 UI の 👍/🎁 ボタンは維持。
+SFU DataChannels API を使用。既存 UI の 👍/🎁 ボタンは維持。
 
-- [ ] **Step 4: package.json から livekit 依存削除**
+- [ ] **Step 4: web/ と livekit/ を削除**
 
 ```bash
-cd web && npm uninstall @livekit/components-react livekit-client
+git rm -r web/ livekit/
+# Makefile から livekit-up/down を削除
 ```
 
-- [ ] **Step 5: E2E 更新**
+- [ ] **Step 5: E2E 新設**
 
-`web/tests/room.page.spec.ts` — LiveKit セレクタを SFU 接続状態バッジに変更。
+`app/e2e/room.spec.ts` — 接続状態バッジ・配信開始フローを Playwright で検証。
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git commit -m "feat: replace LiveKit with Cloudflare Realtime SFU client"
+git commit -m "feat: replace LiveKit/Next.js with SFU client on Vite SPA"
 ```
 
 ---
@@ -449,9 +639,8 @@ git commit -m "fix: release host_identity on stream end and stale timeout"
 ### Task 5: 視聴者数 WebSocket 移行
 
 **Files:**
-- Create: `web/src/lib/room-ws.ts`
-- Modify: `web/src/components/InRoomUI.tsx`
-- Remove: `web/src/pages/api/room/viewers/stream.ts`（Workers 移行後）
+- Create: `app/src/lib/room-ws.ts`（Task 3 で作成済みなら拡張）
+- Modify: `app/src/components/InRoomUI.tsx`
 
 - [ ] **Step 1: room-ws.ts クライアント**
 
@@ -487,7 +676,7 @@ git commit -m "feat: replace SSE viewer count with RoomDO WebSocket"
 
 **Files:**
 - Modify: `worker/src/routes/room.ts`
-- Modify: `web/src/pages/admin/monitor.tsx`
+- Modify: `app/src/routes/admin.monitor.tsx`
 
 - [ ] **Step 1: admin_users シード**
 
@@ -521,7 +710,7 @@ git commit -m "feat: add admin RBAC for monitor page"
 **Files:**
 - Create: `worker/src/lib/rate-limit.ts`
 - Modify: `worker/src/routes/reaction.ts`
-- Modify: `web/src/components/InRoomUI.tsx`
+- Modify: `app/src/components/InRoomUI.tsx`
 
 - [ ] **Step 1: KV レートリミット（10 req/min/user/endpoint）**
 
@@ -542,26 +731,51 @@ git commit -m "feat: add rate limiting and share link"
 
 ---
 
-### Task 8: Pages デプロイ + CI
+### Task 8: Worker デプロイ + CI
 
 **Files:**
 - Modify: `.github/workflows/ci.yml`
 - Create: `.github/workflows/deploy-cloudflare.yml`
+- Modify: `README.md`
 
-- [ ] **Step 1: OpenNext Cloudflare 設定**
+- [ ] **Step 1: GitHub Actions デプロイ**
 
-```bash
-cd web && npx @opennextjs/cloudflare init
+`.github/workflows/deploy-cloudflare.yml`:
+```yaml
+name: Deploy
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: "22" }
+      - run: npm ci
+      - run: npm run build:app
+      - run: npm test
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 ```
 
-- [ ] **Step 2: GitHub Actions — PR で vitest + playwright、main で wrangler deploy**
+- [ ] **Step 2: Secrets を Cloudflare Dashboard + GitHub に設定**
 
-- [ ] **Step 3: 環境変数を Cloudflare Dashboard / wrangler secret に設定**
+Worker secrets: `REALTIME_APP_ID`, `REALTIME_APP_SECRET`, `GOOGLE_*`, `TWITTER_*`  
+OAuth callback: `https://fork-api.<account>.workers.dev/api/auth/google/callback`
+
+- [ ] **Step 3: README を Cloudflare 構成に書き換え**
+
+- LiveKit Docker 手順を削除
+- `npm run dev` / `npm run deploy` に統一
 
 - [ ] **Step 4: Commit**
 
 ```bash
-git commit -m "ci: add Cloudflare Pages and Workers deploy pipeline"
+git commit -m "ci: deploy single Worker with Static Assets via wrangler"
 ```
 
 ---
@@ -594,8 +808,11 @@ git commit -m "ci: add Cloudflare Pages and Workers deploy pipeline"
 | host 解放 | Task 4 |
 | RoomDO WS | Task 1, 5 |
 | D1 スキーマ | Task 0 |
+| Vite SPA（Next.js 全廃） | Task 1B, 3 |
+| Arctic + KV 認証 | Task 1C |
 | RBAC | Task 6 |
 | レートリミット | Task 7 |
-| KV キャッシュ | Task 0 (KV binding), Task 7 拡張で room list |
+| KV キャッシュ | Task 0, Task 7 |
 | Cron cleanup | Task 4 |
-| OpenNext Pages | Task 8 |
+| Workers Static Assets デプロイ | Task 8 |
+| workers.dev（カスタムドメイン任意） | Task 8 |

--- a/docs/superpowers/specs/2026-07-11-fork-cloudflare-design.md
+++ b/docs/superpowers/specs/2026-07-11-fork-cloudflare-design.md
@@ -1,0 +1,266 @@
+# fork — Cloudflare 無料枠 β版 設計書
+
+> 作成日: 2026-07-11  
+> ステータス: Draft（レビュー待ち）
+
+## 1. 目的
+
+音声ライブ配信 MVP「fork」を、**Cloudflare 無料枠のみ**で運用可能な β 版へ進化させる。
+
+### 成功基準
+
+| 指標 | 目標 |
+|------|------|
+| 同時視聴 | 1 ルームあたり最大 30 人（現状 README と同等） |
+| 月間メディア転送 | Realtime SFU 無料枠 1,000 GB 以内 |
+| API 可用性 | Workers 無料枠（10 万 req/日）内で運用 |
+| DB | D1 無料枠（500 万 rows read/日、10 万 write/日）内 |
+| 配信者 UX | 作成 → 配信 → 終了 → 再配信が同一 slug で可能 |
+| 運用 | 管理者のみが `/admin/monitor` にアクセス可能 |
+
+### スコープ外（β 以降）
+
+- 映像配信・録画・VOD
+- 課金・ギフト課金
+- フォロー / 検索 / ランキング
+- RealtimeKit（分課金・無料枠なし）
+
+---
+
+## 2. 現状と課題
+
+### 現状スタック
+
+```
+Browser ──WebRTC──► LiveKit (自前 Docker)
+       ──HTTP────► Next.js (Vercel 想定) + Prisma + SQLite
+       ──SSE─────► 視聴者数ポーリング
+```
+
+### 主要課題（前回洗い出しより）
+
+1. `hostIdentity` が配信終了後も残り、再配信・移譲不可
+2. LiveKit 自前ホスト → Cloudflare 無料枠に含まれない
+3. SSE + Presence 心拍 → D1 write 上限を容易に超過
+4. 管理画面 RBAC なし
+5. チャット非永続・モデレーション弱い
+6. API レートリミットなし
+
+---
+
+## 3. アーキテクチャ案（3 択）
+
+### 案 A: フル Cloudflare 移行（推奨）
+
+```
+Browser ──WebRTC──► Cloudflare Realtime SFU (+ TURN 内包)
+       ──HTTP────► Workers (Hono)
+       ──WS──────► Durable Objects (RoomDO: 視聴者数・チャット)
+       ──Static──► Cloudflare Pages (Next.js via OpenNext)
+       ──SQL─────► D1
+       ──Cache───► Workers KV (ルーム一覧・レートリミット)
+       ──Cron────► Workers Cron (Presence 整理・host 解放)
+```
+
+| 長所 | 短所 |
+|------|------|
+| 無料枠内で完結 | LiveKit → SFU へのクライアント/API 全面差し替え |
+| グローバル edge | Next.js edge 移行の学習コスト |
+| TURN 込みで NAT 越え | Prisma 不可 → Drizzle + D1 |
+
+### 案 B: ハイブリッド（Next.js 温存）
+
+Pages (OpenNext) + 既存 Next API を段階的に Workers へ移行。LiveKit は当面維持。
+
+| 長所 | 短所 |
+|------|------|
+| 移行リスク低 | LiveKit ホストが CF 無料枠外（要件不一致） |
+| 差分小 | Vercel + CF 二重運用 |
+
+### 案 C: SFU のみ Cloudflare
+
+API/DB は現状維持、メディアだけ Realtime SFU。
+
+| 長所 | 短所 |
+|------|------|
+| メディア移行に集中 | 「インフラは CF 無料枠」要件を満たさない |
+
+**推奨: 案 A** — ユーザー要件「インフラは Cloudflare 無料枠」に唯一適合。
+
+---
+
+## 4. ターゲットアーキテクチャ
+
+```mermaid
+flowchart TB
+  subgraph Client
+    UI[Pages: Next.js UI]
+    RTC[WebRTC Client]
+  end
+
+  subgraph Cloudflare
+    WK[Workers API]
+    DO[RoomDO per slug]
+    D1[(D1)]
+    KV[(KV Cache)]
+    SFU[Realtime SFU]
+    CRON[Cron Trigger]
+  end
+
+  UI --> WK
+  UI --> DO
+  RTC --> SFU
+  WK --> D1
+  WK --> KV
+  WK --> SFU
+  DO --> D1
+  CRON --> D1
+  CRON --> DO
+```
+
+### コンポーネント責務
+
+| コンポーネント | 責務 |
+|----------------|------|
+| **Pages** | ロビー・ルーム UI。認証セッション Cookie |
+| **Workers API** | OAuth、ルーム CRUD、SFU セッション発行、BAN、リアクション集計 |
+| **RoomDO** | ルーム単位の WebSocket（視聴者数 push）、直近チャット 200 件、ホスト online 状態 |
+| **D1** | Room / Ban / ReactionAggregate（永続） |
+| **KV** | 公開ルーム一覧キャッシュ（TTL 15s）、API レートリミット |
+| **Realtime SFU** | 音声 publish/subscribe、DataChannel（リアクション broadcast） |
+| **Cron** | 非アクティブ host 解放、古い Presence 削除、KV キャッシュ warm |
+
+---
+
+## 5. 無料枠バジェット
+
+### Realtime SFU（1,000 GB/月）
+
+音声 Opus 64 kbps、1 配信者 + 30 視聴者の場合:
+
+- 下り（課金対象）≈ 30 × 64 kbps ≈ 1.92 Mbps
+- 1 時間 ≈ 0.86 GB
+- **月間 ≈ 1,160 時間**（1 ルーム常時 LITE 換算）
+
+→ 数十人規模・複数ルーム短時間なら十分。常時大規模は不可（意図通り）。
+
+### D1
+
+| 操作 | 現状 MVP | 改善後 |
+|------|----------|--------|
+| Presence 心拍 | 20s ごと D1 upsert | **RoomDO メモリ + WS**（D1 不要） |
+| ルーム一覧 | 毎回 D1 scan | **KV キャッシュ** + 更新時 invalidate |
+| リアクション | 毎回 write | 維持（スパム対策で KV レートリミット） |
+
+見込み: アクティブ 100 ユーザー規模でも D1 無料枠内。
+
+### Workers + DO
+
+| リソース | 無料枠 | 用途 |
+|----------|--------|------|
+| Workers requests | 100,000/日 | API + DO RPC |
+| DO requests | 100,000/日 | Room WebSocket（20:1 課金比率） |
+| DO duration | 13,000 GB-s/日 | **WebSocket Hibernation API 必須** |
+
+---
+
+## 6. データモデル（D1）
+
+```sql
+-- rooms
+CREATE TABLE rooms (
+  name TEXT PRIMARY KEY,
+  display_name TEXT,
+  host_identity TEXT,          -- NULL = 配信可能
+  is_public INTEGER DEFAULT 1,
+  host_last_seen_at TEXT,      -- ISO8601
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- bans
+CREATE TABLE bans (
+  room_name TEXT NOT NULL,
+  identity TEXT NOT NULL,
+  created_at TEXT DEFAULT (datetime('now')),
+  PRIMARY KEY (room_name, identity)
+);
+
+-- reaction_aggregates（個別 reaction 行は β では省略可）
+CREATE TABLE reaction_aggregates (
+  room_name TEXT NOT NULL,
+  type TEXT NOT NULL,
+  count INTEGER DEFAULT 0,
+  PRIMARY KEY (room_name, type)
+);
+
+-- admin_users（RBAC）
+CREATE TABLE admin_users (
+  identity TEXT PRIMARY KEY
+);
+```
+
+### host ライフサイクル
+
+1. 配信開始: `host_identity = me`, `host_last_seen_at = now`
+2. 配信中: RoomDO / Cron が `host_last_seen_at` を更新
+3. 配信終了（明示退出 or SFU session 30s timeout）: **`host_identity = NULL`**
+4. 再配信: 次の publish 要求者が host 取得
+
+---
+
+## 7. API 設計（Workers）
+
+| Method | Path | 説明 |
+|--------|------|------|
+| GET | `/api/auth/*` | OAuth (Google/X) via Auth.js |
+| POST | `/api/room/create` | ルーム作成 |
+| GET | `/api/room/list` | 公開ルーム（KV キャッシュ） |
+| GET | `/api/room/info` | ルームメタ |
+| POST | `/api/room/set-public` | 公開 toggle（host のみ） |
+| POST | `/api/session` | SFU session + tracks 発行 |
+| POST | `/api/reaction/send` | リアクション（レートリミット） |
+| GET | `/api/reaction/summary` | 集計 |
+| POST | `/api/moderation/ban` | BAN（host/admin） |
+| WS | `/api/room/:slug/ws` | RoomDO WebSocket |
+
+---
+
+## 8. フェーズ分割
+
+| Phase | 名称 | 成果物 |
+|-------|------|--------|
+| **0** | Cloudflare 基盤 | Wrangler プロジェクト、D1、Workers 骨格、CI |
+| **1** | メディア移行 | LiveKit 除去、Realtime SFU 音声配信 |
+| **2** | 状態管理刷新 | RoomDO、host 解放、WebSocket 視聴者数 |
+| **3** | β 運用品質 | RBAC、レートリミット、共有リンク、テスト |
+| **4** | 将来 | 映像、R2 録画、発見機能（別 spec） |
+
+---
+
+## 9. リスクと緩和
+
+| リスク | 緩和 |
+|--------|------|
+| SFU API 複雑度 | 公式 example-architecture ベースの `sfu-client` モジュールに集約 |
+| Next.js on CF 制限 | OpenNext adapter。API Routes は Workers へ移行 |
+| DO duration 課金 | Hibernation API + ping 間隔 30s |
+| OAuth on Workers | Auth.js `@auth/core` + D1 session store |
+| 帯域超過 | ルーム人数上限 30、管理画面で egress 概算表示 |
+
+---
+
+## 10. テスト方針
+
+- **Unit**: Vitest + `@cloudflare/vitest-pool-workers`（Workers/DO）
+- **E2E**: 既存 Playwright を SFU mock / staging CF 環境向けに更新
+- **Load**: 30 仮想視聴者 WS 接続テスト（DO 上限確認）
+
+---
+
+## 11. 未決事項（レビューで決定）
+
+1. UI フレームワーク: Next.js (OpenNext) 維持 vs React SPA 化
+2. 認証: Auth.js Workers vs Cloudflare Access（外部 IdP 限定）
+3. カスタムドメイン: 必須かどうか
+
+**デフォルト提案**: Next.js OpenNext 維持、Auth.js Workers、workers.dev → 後日 custom domain

--- a/docs/superpowers/specs/2026-07-11-fork-cloudflare-design.md
+++ b/docs/superpowers/specs/2026-07-11-fork-cloudflare-design.md
@@ -1,7 +1,8 @@
 # fork — Cloudflare 無料枠 β版 設計書
 
 > 作成日: 2026-07-11  
-> ステータス: Draft（レビュー待ち）
+> 更新日: 2026-07-11  
+> ステータス: Approved
 
 ## 1. 目的
 
@@ -54,19 +55,19 @@ Browser ──WebRTC──► LiveKit (自前 Docker)
 
 ```
 Browser ──WebRTC──► Cloudflare Realtime SFU (+ TURN 内包)
-       ──HTTP────► Workers (Hono)
+       ──HTTP────► Workers (Hono) — API + OAuth + SFU トークン
        ──WS──────► Durable Objects (RoomDO: 視聴者数・チャット)
-       ──Static──► Cloudflare Pages (Next.js via OpenNext)
+       ──Static──► Workers Static Assets (Vite + React SPA)
        ──SQL─────► D1
-       ──Cache───► Workers KV (ルーム一覧・レートリミット)
-       ──Cron────► Workers Cron (Presence 整理・host 解放)
+       ──Cache───► Workers KV (セッション・ルーム一覧・レートリミット)
+       ──Cron────► Workers Cron (host 解放・KV warm)
 ```
 
 | 長所 | 短所 |
 |------|------|
-| 無料枠内で完結 | LiveKit → SFU へのクライアント/API 全面差し替え |
-| グローバル edge | Next.js edge 移行の学習コスト |
-| TURN 込みで NAT 越え | Prisma 不可 → Drizzle + D1 |
+| 無料枠内で完結 | Next.js / LiveKit / Prisma を全廃（破壊的変更） |
+| 単一 Worker で API + 静的配信 | 既存 Playwright テストの書き換えが必要 |
+| TURN 込みで NAT 越え | Drizzle + D1 へ ORM 移行 |
 
 ### 案 B: ハイブリッド（Next.js 温存）
 
@@ -94,15 +95,15 @@ API/DB は現状維持、メディアだけ Realtime SFU。
 ```mermaid
 flowchart TB
   subgraph Client
-    UI[Pages: Next.js UI]
+    UI[Vite React SPA]
     RTC[WebRTC Client]
   end
 
   subgraph Cloudflare
-    WK[Workers API]
+    WK[Worker: Hono API + Static Assets]
     DO[RoomDO per slug]
     D1[(D1)]
-    KV[(KV Cache)]
+    KV[(KV: session / cache / rate-limit)]
     SFU[Realtime SFU]
     CRON[Cron Trigger]
   end
@@ -122,8 +123,8 @@ flowchart TB
 
 | コンポーネント | 責務 |
 |----------------|------|
-| **Pages** | ロビー・ルーム UI。認証セッション Cookie |
-| **Workers API** | OAuth、ルーム CRUD、SFU セッション発行、BAN、リアクション集計 |
+| **Worker + Static Assets** | `/api/*` は Hono、`/*` は SPA fallback。同一オリジン |
+| **Workers API (Hono)** | OAuth、ルーム CRUD、SFU セッション発行、BAN、リアクション集計 |
 | **RoomDO** | ルーム単位の WebSocket（視聴者数 push）、直近チャット 200 件、ホスト online 状態 |
 | **D1** | Room / Ban / ReactionAggregate（永続） |
 | **KV** | 公開ルーム一覧キャッシュ（TTL 15s）、API レートリミット |
@@ -212,7 +213,10 @@ CREATE TABLE admin_users (
 
 | Method | Path | 説明 |
 |--------|------|------|
-| GET | `/api/auth/*` | OAuth (Google/X) via Auth.js |
+| GET | `/api/auth/:provider` | OAuth 開始 (Google/X) — Arctic |
+| GET | `/api/auth/:provider/callback` | OAuth コールバック → KV セッション |
+| POST | `/api/auth/logout` | セッション削除 |
+| GET | `/api/auth/me` | 現在ユーザー |
 | POST | `/api/room/create` | ルーム作成 |
 | GET | `/api/room/list` | 公開ルーム（KV キャッシュ） |
 | GET | `/api/room/info` | ルームメタ |
@@ -242,9 +246,9 @@ CREATE TABLE admin_users (
 | リスク | 緩和 |
 |--------|------|
 | SFU API 複雑度 | 公式 example-architecture ベースの `sfu-client` モジュールに集約 |
-| Next.js on CF 制限 | OpenNext adapter。API Routes は Workers へ移行 |
+| Next.js 全廃 | Vite SPA + Workers Static Assets。段階移行せず一括置換 |
 | DO duration 課金 | Hibernation API + ping 間隔 30s |
-| OAuth on Workers | Auth.js `@auth/core` + D1 session store |
+| OAuth on Workers | Arctic + KV セッション + httpOnly Cookie |
 | 帯域超過 | ルーム人数上限 30、管理画面で egress 概算表示 |
 
 ---
@@ -252,15 +256,67 @@ CREATE TABLE admin_users (
 ## 10. テスト方針
 
 - **Unit**: Vitest + `@cloudflare/vitest-pool-workers`（Workers/DO）
-- **E2E**: 既存 Playwright を SFU mock / staging CF 環境向けに更新
+- **E2E**: Playwright を Vite SPA + staging Worker 向けに書き直し（`app/e2e/`）
 - **Load**: 30 仮想視聴者 WS 接続テスト（DO 上限確認）
 
 ---
 
-## 11. 未決事項（レビューで決定）
+## 11. 決定事項（2026-07-11 確定）
 
-1. UI フレームワーク: Next.js (OpenNext) 維持 vs React SPA 化
-2. 認証: Auth.js Workers vs Cloudflare Access（外部 IdP 限定）
-3. カスタムドメイン: 必須かどうか
+破壊的変更を許容し、Cloudflare 無料枠との相性を最優先して以下を確定する。
 
-**デフォルト提案**: Next.js OpenNext 維持、Auth.js Workers、workers.dev → 後日 custom domain
+### 11.1 フロントエンド — Vite + React SPA（Next.js 全廃）
+
+| 項目 | 決定 | 理由 |
+|------|------|------|
+| フレームワーク | **Vite 6 + React 19 + TypeScript** | ビルド成果物が静的ファイルのみ。Pages / Workers Static Assets に最適 |
+| ルーティング | **TanStack Router** | 型安全。ファイルベースルートで `/`, `/room/$slug`, `/admin/monitor` |
+| 状態管理 | React hooks のみ（β では Zustand 不導入） | YAGNI |
+| 配置 | **Workers Static Assets**（`[assets]` binding） | API と SPA を同一 Worker・同一オリジン。CORS 不要 |
+| 廃止 | `web/`（Next.js Pages Router）全体 | API Routes / NextAuth / Prisma / LiveKit SDK をすべて除去 |
+
+```toml
+# wrangler.toml（抜粋）
+[assets]
+directory = "./app/dist"
+not_found_handling = "single-page-application"
+binding = "ASSETS"
+```
+
+### 11.2 認証 — Arctic + KV セッション（Cloudflare Access は不採用）
+
+| 項目 | 決定 | 理由 |
+|------|------|------|
+| OAuth ライブラリ | **[Arctic](https://arcticjs.dev/)** | Edge / Workers ネイティブ。Google・X (Twitter) 対応 |
+| セッション保存 | **Workers KV** | D1 write を消費しない。TTL 付き自動失効 |
+| Cookie | `__Host-fork-session`（httpOnly, Secure, SameSite=Lax） | セッション ID のみ。ペイロードは KV 参照 |
+| 不採用 | Cloudflare Access | Zero Trust 向け。一般ユーザー向け Google/X ログインには不向き |
+| 不採用 | Auth.js / NextAuth | Next.js 依存。Workers 単体ではオーバーヘッド大 |
+
+**セッションフロー:**
+
+```
+1. GET /api/auth/google → Arctic redirect
+2. GET /api/auth/google/callback → KV.put(sessionId, { userId, name, ... }, { expirationTtl: 604800 })
+3. Set-Cookie: __Host-fork-session=<sessionId>
+4. 以降 API は Cookie → KV lookup → identity 解決
+```
+
+### 11.3 ドメイン — β は `*.workers.dev` / `*.pages.dev`、カスタムドメインは任意
+
+| 項目 | 決定 | 理由 |
+|------|------|------|
+| β 環境 | `fork-api.<account>.workers.dev` または Pages 自動 URL | 無料・即デプロイ。OAuth callback URL をここに設定 |
+| 本番 | カスタムドメインは **Phase 3 以降**に Cloudflare DNS で追加 | β ブロッカーにしない |
+| OAuth callback | デプロイ URL に合わせて Google/X コンソールを更新 | ドメイン確定後に再設定 |
+
+### 11.4 その他の技術選定
+
+| 領域 | 決定 |
+|------|------|
+| ORM | Drizzle ORM + D1 |
+| HTTP フレームワーク | Hono |
+| テスト (Worker) | Vitest + `@cloudflare/vitest-pool-workers` |
+| テスト (UI) | Playwright（`app/e2e/` に新設） |
+| モノレポ | npm workspaces: `app/`, `worker/`, `packages/db/` |
+| CI | GitHub Actions → `wrangler deploy`（単一 Worker） |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

音声ライブ配信 MVP「fork」を Cloudflare 無料枠のみで運用可能な β 版へ進化させるための設計書と実装計画。

## 更新（2026-07-11）

未決事項を確定。破壊的変更 OK・Cloudflare 相性優先。

| 項目 | 決定 |
|------|------|
| フロント | **Vite + React SPA**（Next.js 全廃） |
| 配信 | **Workers Static Assets** + 同一 Worker API |
| 認証 | **Arctic + KV セッション**（Access / Auth.js 不採用） |
| ドメイン | β は `*.workers.dev`、カスタムドメインは任意 |

## ドキュメント

- 設計書: `docs/superpowers/specs/2026-07-11-fork-cloudflare-design.md`
- 実装計画: `docs/superpowers/plans/2026-07-11-fork-cloudflare-beta.md`

## フェーズ

- **Phase 0:** Wrangler / D1 / Workers / Vite SPA / Arctic OAuth
- **Phase 1:** Realtime SFU（LiveKit + web/ 削除）
- **Phase 2:** RoomDO + hostIdentity 解放
- **Phase 3:** RBAC / レートリミット / wrangler deploy CI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4fde-451f-78fb-a42c-c34d1565e23d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4fde-451f-78fb-a42c-c34d1565e23d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

