### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`fork` is a live-audio streaming app that runs as a **single Cloudflare Worker** (Hono API +
+Durable Objects) which also serves the Vite/React SPA via the `ASSETS` binding. There is only one
+service to run locally.
+
+Standard commands live in `README.md` and `package.json` scripts; prefer those. The notes below are
+non-obvious caveats discovered during setup (the update script already runs `npm install`).
+
+### Running the app (dev)
+- `npm run dev` builds the SPA and starts `wrangler dev` on http://localhost:8787 (API + SPA).
+- Before tests or dev work, the local D1 database must be migrated:
+  `npx wrangler d1 migrations apply fork --local` (state lives under `.wrangler/`, gitignored).
+- Use the **Devログイン** button on the lobby to sign in without OAuth. This only works because
+  `APP_URL` contains `localhost` (see `worker/src/routes/auth.ts`); Google/X OAuth need secrets.
+
+### Tests / typecheck
+- `npm run typecheck` and `npm run test` (worker vitest via `@cloudflare/vitest-pool-workers`).
+- Non-obvious: `npm run test` fails with `assets.directory ... does not exist` unless `app/dist`
+  exists, because `wrangler.toml` points `assets.directory` at `./app/dist`. Run `npm run build:app`
+  first (CI runs `build:app` before `test` for this reason).
+
+### Known local-only quirks (not environment bugs)
+- `GET /api/room/list` **without** `?onlyLive=true` returns 500 locally: the cache path calls
+  `KV.put(..., { expirationTtl: 15 })` and local miniflare requires TTL ≥ 60. The SPA only calls
+  `/api/room/list?onlyLive=true`, which skips that path, so the lobby is unaffected.
+- Entering a room shows `session/new failed: 503` unless `REALTIME_APP_ID` / `REALTIME_APP_SECRET`
+  (Cloudflare Realtime SFU) are configured. Room creation, auth, chat UI, and navigation still work;
+  only live audio publishing/subscribing needs those secrets.
+- Terraform is only used for staging/production infra (`infra/`); it is not needed for local dev.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

このリポジトリ (`fork` — Cloudflare Workers 上の音声ライブ配信アプリ) の開発環境をセットアップし、動作を確認しました。コードの変更はなく、`AGENTS.md` を追加しただけです。

## セットアップ内容

- `npm install`（ワークスペース: `app` / `worker` / `packages/shared`）
- ローカル D1 マイグレーション適用: `npx wrangler d1 migrations apply fork --local`
- SPA ビルド + Worker 起動: `npm run dev`（http://localhost:8787）

**Update script**（起動時の依存更新のみ）: `npm install`

## 検証

| チェック | コマンド | 結果 |
|------|---------|------|
| 型チェック | `npm run typecheck` | ✅ |
| Worker テスト | `npm run build:app` → `npm run test` | ✅ (1 passed) |
| ビルド | `npm run build:app` | ✅ |
| 起動 | `npm run dev` | ✅ http://localhost:8787 |

## Hello World

Dev ログイン → 配信タイトル入力 → 「配信を開始」でルーム作成 → ルームページへ遷移、という中核フローをブラウザで確認しました。

[fork_dev_login_create_room.mp4](https://cursor.com/agents/bc-6c443dcb-0310-4f0f-913c-dd1159d2ac71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffork_dev_login_create_room.mp4)

[lobby before login](https://cursor.com/agents/bc-6c443dcb-0310-4f0f-913c-dd1159d2ac71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flobby_before_login.webp)
[after dev login](https://cursor.com/agents/bc-6c443dcb-0310-4f0f-913c-dd1159d2ac71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_dev_login.webp)
[room page created](https://cursor.com/agents/bc-6c443dcb-0310-4f0f-913c-dd1159d2ac71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froom_page_created.webp)

## 注意点（環境の不具合ではありません）

- `npm run test` は `app/dist` が必要（`wrangler.toml` の `assets.directory`）。先に `npm run build:app` を実行（CI と同じ順序）。
- `GET /api/room/list`（`onlyLive` なし）はローカルで 500 になる（KV の `expirationTtl: 15` < 60）。UI は `?onlyLive=true` のみ使用するため影響なし。
- ルーム入室時の `session/new failed: 503` は Realtime SFU シークレット未設定のため（想定内）。

詳細は `AGENTS.md` の `## Cursor Cloud specific instructions` を参照。

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c443dcb-0310-4f0f-913c-dd1159d2ac71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c443dcb-0310-4f0f-913c-dd1159d2ac71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

